### PR TITLE
Add database initializer CLI and automate arXiv feed ingestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,13 @@ uv sync
     GMAIL_CREDENTIALS_PATH=
     GMAIL_TOKEN_PATH=secrets/token.json
     ```
-7) Initializer database
-``` bash
-uv run python ...
+7) Initialise the database
+```bash
+uv run python curaitor_agent/data_initializer.py --pdf-dir papers
 ```
+  - Replace `papers` with the folder containing your PDFs. The script respects
+    `config.yaml` defaults for chunking and embeddings, and accepts overrides
+    such as `--chunk-size 800 --chunk-overlap 80 --embedding-model sentence-transformers/all-MiniLM-L6-v2`.
 
 8) Run gmail authentication
 This will work for 1 hour.

--- a/curaitor_agent/data_initializer.py
+++ b/curaitor_agent/data_initializer.py
@@ -1,0 +1,169 @@
+"""Command-line entry point to prime the Curaitor PDF database."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Iterable, Optional
+
+import yaml
+
+try:  # pragma: no cover - import guard for script vs module execution
+    from curaitor_agent.pdf_repository import (
+        DEFAULT_DB_PATH,
+        collect_documents_from_directory,
+        store_documents,
+    )
+except ModuleNotFoundError:  # Running as ``python curaitor_agent/data_initializer.py``
+    from pdf_repository import (  # type: ignore[F401]
+        DEFAULT_DB_PATH,
+        collect_documents_from_directory,
+        store_documents,
+    )
+
+
+def _load_config_defaults() -> dict[str, object]:
+    """Return default values derived from ``config.yaml`` when available."""
+
+    config_path = Path("config.yaml")
+    if not config_path.exists():
+        return {}
+
+    with config_path.open("r", encoding="utf-8") as fh:
+        config = yaml.safe_load(fh) or {}
+
+    defaults: dict[str, object] = {}
+    try:
+        sources = config.get("source", [])
+        if isinstance(sources, list) and sources:
+            pdf_path = sources[0].get("pdf_path") if isinstance(sources[0], dict) else None
+            if pdf_path:
+                defaults["pdf_dir"] = pdf_path
+    except AttributeError:
+        pass
+
+    rag_cfg = config.get("rag", {}) if isinstance(config, dict) else {}
+    if isinstance(rag_cfg, dict):
+        if "chunk_size" in rag_cfg:
+            defaults["chunk_size"] = rag_cfg["chunk_size"]
+        if "overlap" in rag_cfg:
+            defaults["chunk_overlap"] = rag_cfg["overlap"]
+        if "embedding_model" in rag_cfg:
+            defaults["embedding_model"] = rag_cfg["embedding_model"]
+        if "embedding_prefix" in rag_cfg:
+            defaults["embedding_prefix"] = rag_cfg["embedding_prefix"]
+
+    return defaults
+
+
+def _parse_args(argv: Optional[Iterable[str]] = None) -> argparse.Namespace:
+    defaults = _load_config_defaults()
+
+    parser = argparse.ArgumentParser(
+        description="Load PDFs into the Curaitor SQLite cache so they are ready for RAG queries.",
+    )
+    parser.add_argument(
+        "--pdf-dir",
+        default=defaults.get("pdf_dir", "data/papers"),
+        help="Directory containing PDF files to ingest (defaults to config.yaml source path).",
+    )
+    parser.add_argument(
+        "--db-path",
+        default=str(DEFAULT_DB_PATH),
+        help="Path to the SQLite database file to initialise.",
+    )
+    parser.add_argument(
+        "--max-pdfs",
+        type=int,
+        default=100,
+        help="Maximum number of PDFs to parse from the directory.",
+    )
+    parser.add_argument(
+        "--max-pages",
+        type=int,
+        default=10,
+        help="Maximum number of pages to read per PDF.",
+    )
+    parser.add_argument(
+        "--per-page-chars",
+        type=int,
+        default=None,
+        help="Optional character cap applied to each page while parsing.",
+    )
+    parser.add_argument(
+        "--max-chars",
+        type=int,
+        default=None,
+        help="Optional character cap for the full PDF text.",
+    )
+    parser.add_argument(
+        "--chunk-size",
+        type=int,
+        default=defaults.get("chunk_size", 1000),
+        help="Token chunk size to use when storing documents.",
+    )
+    parser.add_argument(
+        "--chunk-overlap",
+        type=int,
+        default=defaults.get("chunk_overlap", 100),
+        help="Overlap between consecutive chunks.",
+    )
+    parser.add_argument(
+        "--embedding-model",
+        default=defaults.get("embedding_model"),
+        help="Optional sentence-transformers model name for embedding storage.",
+    )
+    parser.add_argument(
+        "--embedding-prefix",
+        default=defaults.get("embedding_prefix"),
+        help="Prompt prefix applied before creating embeddings (ignored when no model).",
+    )
+
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[Iterable[str]] = None) -> None:
+    args = _parse_args(argv)
+
+    pdf_dir = Path(args.pdf_dir).expanduser().resolve()
+    if not pdf_dir.exists():
+        raise SystemExit(f"PDF directory '{pdf_dir}' does not exist")
+
+    documents = collect_documents_from_directory(
+        pdf_dir,
+        max_pdfs=args.max_pdfs,
+        max_pages=args.max_pages,
+        per_page_chars=args.per_page_chars,
+        max_chars=args.max_chars,
+    )
+
+    if not documents:
+        print(f"No PDFs parsed from {pdf_dir}. Nothing to store.")
+        return
+
+    db_path = Path(args.db_path).expanduser().resolve()
+
+    embedding_prefix = args.embedding_prefix
+    if args.embedding_model and not embedding_prefix:
+        embedding_prefix = "search_document: "
+
+    store_documents(
+        documents,
+        db_path=db_path,
+        chunk_size=args.chunk_size,
+        chunk_overlap=args.chunk_overlap,
+        embedding_model=args.embedding_model,
+        embedding_prefix=embedding_prefix if args.embedding_model else None,
+    )
+
+    print("Initialisation complete:")
+    print(f"  Database: {db_path}")
+    print(f"  Documents stored: {len(documents)}")
+    print(f"  Chunk size / overlap: {args.chunk_size} / {args.chunk_overlap}")
+    if args.embedding_model:
+        print(f"  Embeddings: {args.embedding_model} (prefix='{embedding_prefix}')")
+    else:
+        print("  Embeddings: disabled")
+
+
+if __name__ == "__main__":
+    main()

--- a/curaitor_agent/prompts/curaitor_tools.md
+++ b/curaitor_agent/prompts/curaitor_tools.md
@@ -1,0 +1,34 @@
+# Curaitor MCP Tool Reference
+
+The Curaitor stack exposes the following MCP tools via `curaitor_agent/curaitor_mcp_server.py`. Use them to orchestrate
+literature discovery, ingestion, retrieval, and notifications. Unless noted otherwise, parameters are optional and
+fall back to `config.yaml` defaults.
+
+## Discovery and ingestion
+- **`extract_keywords_only`** — Run the LLM keyword extractor against a natural-language topic and return a ranked list of
+  suggested search terms.
+- **`search_arxiv_titles_only`** — Query arXiv using explicit keywords and return lightweight metadata (title, link,
+  summary) without downloading PDFs.
+- **`download_specific_papers`** — Download one or more PDF URLs directly into the configured papers directory and report
+  success/failure for each file.
+- **`ingest_local_pdfs`** — Parse locally available PDFs (with optional limits on count, pages, or character lengths) and
+  persist chunks plus embeddings into the SQLite repository. Use this after manual downloads or when seeding the cache.
+- **`refresh_arxiv_feed`** — End-to-end workflow: extract keywords from a topic, search arXiv, download the newest papers,
+  store them, and optionally send an email summary via Gmail.
+
+## Retrieval and analysis
+- **`chat_with_repository`** — Retrieve the most relevant stored chunks with FAISS (falling back to keyword search when
+  no embeddings exist) and answer a question with detailed context metadata.
+- **`quick_pdf_search`** — Perform a fast filename-based relevance scan across the local PDF directory.
+- **`extract_pdf_text_only`** — Pull cleaned text for a single PDF without performing a full ingestion run.
+- **`simple_qa_from_text`** — Answer a question directly against caller-provided text, bypassing the repository entirely.
+
+## Communication
+- **`send_email_tool`** — Deliver plain-text or HTML messages through Gmail. Returns structured success metadata or an
+  explicit authentication error with an OAuth URL.
+
+## Scheduling
+- **`add_daily_job`** — Ensure the APScheduler service is running and schedule a persistent daily refresh job for a given
+  topic at `hour:minute`.
+- **`delete_job`** — Remove a scheduled job by ID.
+- **`jobs`** — List all scheduled jobs currently persisted by the scheduler service.


### PR DESCRIPTION
## Summary
- add a configurable `curaitor_agent/data_initializer.py` CLI to populate the SQLite cache before running the agent
- extend the MCP server with ingestion, feed refresh, and repository chat tools plus optional Gmail notifications
- expose a persistent scheduler job for arXiv refreshes and register the new MCP toolset with the ADK agent
- document the MCP tool capabilities in a dedicated prompt file and surface the reference in the agent instruction
- harden the data initializer imports so the CLI also works when executed as a script

## Testing
- ✅ `python3 -m compileall curaitor_agent/data_initializer.py curaitor_agent/agent.py`

------
https://chatgpt.com/codex/tasks/task_e_68e18473b58c8329af15129b8f4af09e